### PR TITLE
Double right click to store all like items

### DIFF
--- a/src/main/java/me/benfah/simpledrawers/api/drawer/BlockAbstractDrawer.java
+++ b/src/main/java/me/benfah/simpledrawers/api/drawer/BlockAbstractDrawer.java
@@ -63,7 +63,7 @@ public abstract class BlockAbstractDrawer extends BlockWithEntity implements Inv
         {
             if(hand.equals(Hand.MAIN_HAND))
             {
-            	if(player.getMainHandStack().isEmpty())
+            	if(player.getMainHandStack().isEmpty() && !(player.getUuid().equals(lastUsedPlayer) && world.getTime() - lastUsedTime < 10))
             	{
             		ContainerProviderRegistry.INSTANCE.openContainer(getContainerIdentifier(), player, (buf) ->
                     {

--- a/src/main/java/me/benfah/simpledrawers/api/drawer/BlockAbstractDrawer.java
+++ b/src/main/java/me/benfah/simpledrawers/api/drawer/BlockAbstractDrawer.java
@@ -1,6 +1,6 @@
 package me.benfah.simpledrawers.api.drawer;
 
-import java.util.Arrays;
+import java.util.UUID;
 
 import me.benfah.simpledrawers.api.border.Border;
 import me.benfah.simpledrawers.api.border.BorderRegistry;

--- a/src/main/java/me/benfah/simpledrawers/api/drawer/BlockAbstractDrawer.java
+++ b/src/main/java/me/benfah/simpledrawers/api/drawer/BlockAbstractDrawer.java
@@ -97,7 +97,7 @@ public abstract class BlockAbstractDrawer extends BlockWithEntity implements Inv
             	}
             }
         }
-        return ActionResult.PASS;
+        return ActionResult.CONSUME;
     }
 
     @Override

--- a/src/main/java/me/benfah/simpledrawers/api/drawer/BlockAbstractDrawer.java
+++ b/src/main/java/me/benfah/simpledrawers/api/drawer/BlockAbstractDrawer.java
@@ -46,6 +46,8 @@ public abstract class BlockAbstractDrawer extends BlockWithEntity implements Inv
 
     public Identifier borderIdentifier;
 
+    private UUID lastUsedPlayer;
+    private long lastUsedTime;
 
     public BlockState rotate(BlockState state, BlockRotation rotation)
     {
@@ -78,7 +80,20 @@ public abstract class BlockAbstractDrawer extends BlockWithEntity implements Inv
 	                            drawer.getItemHolderAt(interactPos.x, interactPos.y));
 	                    return ActionResult.SUCCESS;
 	                }
-	                return drawer.getItemHolderAt(interactPos.x, interactPos.y).offer(player.getMainHandStack());
+                        //If this is a valid double right click, store all valid items from the inventory
+                    if (player.getUuid().equals(lastUsedPlayer) && world.getTime() - lastUsedTime < 10)
+                    {
+                        lastUsedPlayer = player.getUuid();
+                        lastUsedTime = world.getTime();
+                        return drawer.getItemHolderAt(interactPos.x, interactPos.y).offerAll(player.getMainHandStack(), player);
+                    }
+                        //If this isn't a valid double right click, store only the held stack
+                    else
+                    {
+                        lastUsedPlayer = player.getUuid();
+                        lastUsedTime = world.getTime();
+                        return drawer.getItemHolderAt(interactPos.x, interactPos.y).offer(player.getMainHandStack());
+                    }
             	}
             }
         }

--- a/src/main/java/me/benfah/simpledrawers/api/drawer/holder/ItemHolder.java
+++ b/src/main/java/me/benfah/simpledrawers/api/drawer/holder/ItemHolder.java
@@ -4,6 +4,7 @@ import me.benfah.simpledrawers.api.border.BorderRegistry;
 import me.benfah.simpledrawers.api.drawer.blockentity.BlockEntityAbstractDrawer;
 import me.benfah.simpledrawers.utils.NumberUtils;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.Inventory;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;

--- a/src/main/java/me/benfah/simpledrawers/api/drawer/holder/ItemHolder.java
+++ b/src/main/java/me/benfah/simpledrawers/api/drawer/holder/ItemHolder.java
@@ -68,6 +68,28 @@ public class ItemHolder
         }
         return ActionResult.CONSUME;
     }
+    
+    public ActionResult offerAll(ItemStack stack, PlayerEntity player)
+    {
+        Inventory inventory = player.inventory;
+        for (int i = 0; i < inventory.size(); i++)
+        {
+            ItemStack currentStack = inventory.getStack(i);
+            if (!currentStack.isEmpty() && isStackEqual(currentStack))
+            {
+                int newAmount = Math.min(amount + currentStack.getCount(), getMaxAmount());
+                int stackSize = (amount + currentStack.getCount()) - newAmount;
+                currentStack.setCount(stackSize);
+                amount = newAmount;
+                blockEntity.sync();
+                if (amount == getMaxAmount())
+                {
+                    break;
+                }
+            }
+        }
+        return ActionResult.CONSUME;
+    }
 
     public boolean shouldOffer(ItemStack stack)
     {


### PR DESCRIPTION
I spent some time putting this together in response to this mod lacking Storage Drawers' ability to store all items from one's inventory that match the item on the front of the drawer that they are pointing at, which is pointed out by #16 . This branch simply adjusts BlockAbstractDrawer.java to check a timer and the UUID of the player to last use the drawer to determine if a double right click occurred, and run a new method, offerAll, in ItemHolder.java to loop through the inventory and store all like items up to the drawer's maximum capacity.~