### PR TITLE
Fix wrong type of ModelLoaderMixin.bakedModels shadowed field

### DIFF
--- a/src/main/java/me/benfah/simpledrawers/callback/ModelPostBakeCallback.java
+++ b/src/main/java/me/benfah/simpledrawers/callback/ModelPostBakeCallback.java
@@ -4,6 +4,7 @@ import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.util.ModelIdentifier;
+import net.minecraft.util.Identifier;
 
 import java.util.Map;
 
@@ -19,6 +20,6 @@ public interface ModelPostBakeCallback
                 }
             });
 
-    void onPostBake(Map<ModelIdentifier, BakedModel> baked);
+    void onPostBake(Map<Identifier, BakedModel> baked);
 
 }

--- a/src/main/java/me/benfah/simpledrawers/callback/ModelPreBakeCallback.java
+++ b/src/main/java/me/benfah/simpledrawers/callback/ModelPreBakeCallback.java
@@ -24,6 +24,6 @@ public interface ModelPreBakeCallback
             });
 
     void onPreBake(Map<Identifier, UnbakedModel> unbaked, BiFunction<Identifier, ModelBakeSettings, BakedModel> bakeFunction,
-                   Map<ModelIdentifier, BakedModel> baked);
+                   Map<Identifier, BakedModel> baked);
 
 }

--- a/src/main/java/me/benfah/simpledrawers/mixin/client/ModelLoaderMixin.java
+++ b/src/main/java/me/benfah/simpledrawers/mixin/client/ModelLoaderMixin.java
@@ -21,7 +21,7 @@ public class ModelLoaderMixin
 {
 
     @Shadow
-    Map<ModelIdentifier, BakedModel> bakedModels;
+    Map<Identifier, BakedModel> bakedModels;
 
     @Shadow
     Map<Identifier, UnbakedModel> modelsToBake;

--- a/src/main/java/me/benfah/simpledrawers/models/ModelMerger.java
+++ b/src/main/java/me/benfah/simpledrawers/models/ModelMerger.java
@@ -29,14 +29,15 @@ public class ModelMerger implements ModelPostBakeCallback, ModelPreBakeCallback
 {
 
     @Override
-    public void onPostBake(Map<ModelIdentifier, BakedModel> baked)
+    public void onPostBake(Map<Identifier, BakedModel> baked)
     {
         Map<ModelIdentifier, BakedModel> toAdd = new HashMap<>();
-        for(Entry<ModelIdentifier, BakedModel> modelEntry : baked.entrySet())
+        for(Entry<Identifier, BakedModel> modelEntry : baked.entrySet())
         {
-            if(modelEntry.getKey().toString().contains("border_type"))
+            if(modelEntry.getKey() instanceof ModelIdentifier && modelEntry.getKey().toString().contains("border_type"))
             {
-                Map<String, String> variantMap = variantToMap(modelEntry.getKey().getVariant());
+                ModelIdentifier modelIdentifier = (ModelIdentifier) modelEntry.getKey();
+                Map<String, String> variantMap = variantToMap(modelIdentifier.getVariant());
                 if(variantMap.containsKey("border_type"))
                 {
 
@@ -47,7 +48,7 @@ public class ModelMerger implements ModelPostBakeCallback, ModelPreBakeCallback
 
                     BakedModel borderModel = baked.get(
                             new ModelIdentifier(borderIdentifier, "facing=" + variantMap.get("facing")));
-                    toAdd.put(modelEntry.getKey(), new WrappedBakedModel(modelEntry.getValue(), borderModel));
+                    toAdd.put(modelIdentifier, new WrappedBakedModel(modelEntry.getValue(), borderModel));
                 }
             }
 
@@ -58,7 +59,7 @@ public class ModelMerger implements ModelPostBakeCallback, ModelPreBakeCallback
 
     @Override
     public void onPreBake(Map<Identifier, UnbakedModel> unbaked,
-                          BiFunction<Identifier, ModelBakeSettings, BakedModel> bakeFunction, Map<ModelIdentifier, BakedModel> baked)
+                          BiFunction<Identifier, ModelBakeSettings, BakedModel> bakeFunction, Map<Identifier, BakedModel> baked)
     {
         List<Identifier> toBake = BorderRegistry.getBorders().stream()
                 .flatMap((border) -> border.getModelMap().values().stream()).collect(Collectors.toList());


### PR DESCRIPTION
The motivation behind this PR is to fix incompatibility with Enhanced Block Entities: https://github.com/FoundationGames/EnhancedBlockEntities/issues/21 but it could potentially fix issues with other mods that similarly use fabric api's `ModelLoadingRegistry.registerModelProvider()` interface.